### PR TITLE
Build with -fshort-wchar so toggle passwords work right.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ else
 	default_strict=no
 fi
 
-WARNINGFLAGS_C="$WARNINGFLAGS_C -std=gnu11"
+WARNINGFLAGS_C="$WARNINGFLAGS_C -std=gnu11 -fshort-wchar"
 
 AC_ARG_ENABLE(strict, AS_HELP_STRING([--enable-strict],[Enable strict compilation options]), enable_strict=$enableval,
 		enable_strict=$default_strict)

--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -1351,10 +1351,12 @@ identify_hash_type (const char *hash_str, efi_guid_t *type)
 	}
 
 	switch (len) {
+#if 0
 	case SHA_DIGEST_LENGTH*2:
 		*type = efi_guid_sha1;
 		hash_size = SHA_DIGEST_LENGTH;
 		break;
+#endif
 	case SHA224_DIGEST_LENGTH*2:
 		*type = efi_guid_sha224;
 		hash_size = SHA224_DIGEST_LENGTH;


### PR DESCRIPTION
This source tree uses:

typedef wchar_t efi_char16_t;

to define UEFI's UCS-2 character type.  On many platforms, wchar_t is
32-bits by default.  As a result, efichar_from_char winds up writing
4-byte characters instead of 2-byte characters.  In the case where we
hash the password in mokutil, this works fine, because the same datatype
is used, and the values are the same.  But for our feature toggles,
where we store the raw data and shim is interpretting the character
array, every other character winds up being L'\0', and verification
fails.

So always build with -fshort-wchar to ensure we get 2-byte character
storage.

Signed-off-by: Peter Jones <pjones@redhat.com>