### PR TITLE
Fix typo in error message when the system lacks Secure Boot support

### DIFF
--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -2297,7 +2297,7 @@ main (int argc, char *argv[])
 		rc = efi_get_variable (efi_guid_global, "SecureBoot",
 				       &data, &data_size, &attributes);
 		if (rc < 0) {
-			fprintf(stderr, "This system does't support Secure Boot\n");
+			fprintf(stderr, "This system doesn't support Secure Boot\n");
 			ret = -1;
 			goto out;
 		}


### PR DESCRIPTION
Signed-off-by: Tyler Hicks <tyhicks@canonical.com>