### PR TITLE
Fix compile failure on platforms where int != unsigned int

### DIFF
--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -2005,7 +2005,7 @@ generate_pw_hash (const char *input_pw)
 	char *password = NULL;
 	char *crypt_string;
 	const char *prefix;
-	int settings_len = sizeof (settings) - 2;
+	unsigned int settings_len = sizeof (settings) - 2;
 	unsigned int pw_len, salt_size;
 
 	if (input_pw) {


### PR DESCRIPTION
The compiler may rightly warn about a comparison between an unsigned int and
an int on architectures where int is signed by default.  Since the existing
code has been tested on architectures where int *is* unsigned, we just make
our other int explicitly unsigned, ignoring certain existing corner cases
for now wrt possible integer underflows.

Signed-off-by: Steve Langasek <steve.langasek@canonical.com>