### PR TITLE
mokutil: Add option to print the UEFI SBAT variable content

### DIFF
--- a/man/mokutil.1
+++ b/man/mokutil.1
@@ -71,6 +71,8 @@ mokutil \- utility to manipulate machine owner keys
 .br
 \fBmokutil\fR [--dbx]
 .br
+\fBmokutil\fR [--sbat]
+.br
 \fBmokutil\fR [--timeout \fI-1,0..0x7fff\fR]
 .br
 
@@ -167,6 +169,9 @@ List the keys in the secure boot signature store (db)
 .TP
 \fB--dbx\fR
 List the keys in the secure boot blacklist signature store (dbx)
+.TP
+\fB--sbat\fR
+List the entries in the Secure Boot Advanced Targeting store (SBAT)
 .TP
 \fB--timeout\fR
 Set the timeout for MOK prompt


### PR DESCRIPTION
This variable contains the descriptive form of all the components used by
the operating systems that ship signed shim binaries. Along with a minimum
generation number for each component. More information in can be found in
the UEFI Secure Boot Advanced Targeting (SBAT) specification:

  https://github.com/rhboot/shim/blob/main/SBAT.md

Since a SBAT variable contains a set of Comma Separated Values (CSV) UTF-8
encoded strings, the data could just be printed without the need to do any
previous processing.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>