### PR TITLE
mokutil: add mok-variables parsing support

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -35,6 +35,11 @@
 #include <efivar.h>
 #include "mokutil.h"
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int mok_get_variable(const char *name, uint8_t **datap, size_t *data_sizep);
 MokListNode *build_mok_list (const void *data, const uintptr_t data_size,
 			     uint32_t *mok_num);
 int test_and_delete_mok_var (const char *var_name);


### PR DESCRIPTION
This patch adds support for getting mok variables from
/sys/firmware/efi/mok-variables/$NAME , if they are present, as well as
for checking MokListRT, MokListRT1, MokListRT2, etc., for any of the mok
variables.

Signed-off-by: Peter Jones <pjones@redhat.com>