### PR TITLE
mokutil: Read the SbatLevelRT variable to get the SBAT content

### DIFF
--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -2084,7 +2084,7 @@ main (int argc, char *argv[])
 			ret = set_timeout (timeout);
 			break;
 		case LIST_SBAT:
-			ret = print_var_content ("SBAT", efi_guid_shim);
+			ret = print_var_content ("SbatLevelRT", efi_guid_shim);
 			break;
 		default:
 			print_help ();


### PR DESCRIPTION
The SBAT data was previously in an EFI variable called "SBAT" but this
got renamed to "SbatLevelRT" in the following shim commit:

https://github.com/rhboot/shim/commit/27da4170f0f

Read the new variable instead of the old one that is not used anymore.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>