### PR TITLE
src/util.c: fix NULL pointer dereference in mok_get_variable

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -47,7 +47,7 @@ mok_get_variable(const char *name, uint8_t **datap, size_t *data_sizep)
 	ssize_t ssz;
 
 	*datap = 0;
-	data_sizep = 0;
+	*data_sizep = 0;
 
 	snprintf(filename, filename_sz, "/sys/firmware/efi/mok-variables/%s", name);
 


### PR DESCRIPTION
Instead of setting the passed data_sizeop to NULL pointer, only reset the value it points to.