### PR TITLE
efi_x509: fix certificates fingerprint calculation

### DIFF
--- a/src/efi_x509.c
+++ b/src/efi_x509.c
@@ -42,9 +42,10 @@ print_x509 (const uint8_t *cert, const int cert_size)
 	EVP_MD_CTX *ctx;
 	const EVP_MD *md;
 	unsigned int md_len;
+	const unsigned char *in = (const unsigned char *)cert;
 	unsigned char fingerprint[EVP_MAX_MD_SIZE];
 
-	X509cert = d2i_X509 (NULL, &cert, cert_size);
+	X509cert = d2i_X509 (NULL, &in, cert_size);
 	if (X509cert == NULL) {
 		fprintf (stderr, "Invalid X509 certificate\n");
 		return -1;


### PR DESCRIPTION
Commit a2bffce159d ("efi_x509: convert the cert to X509 directly") stopped
using a BIO buffer and instead just created a X509 object directly.

Unfortunately that change also broke the certs fingerprint calculation due
a behaviour of the d2i_X509() function that's not intuitive at all.

The function modifies the value of the pointer passed as second argument,
which points to the certificate data. This causes the SHA1 digests to be
calculated against the wrong buffers and leads to invalid fingerprints:

Before the mentioned commit:

```
./src/mokutil --db | grep -i fingerprint
SHA1 Fingerprint: 7b:9e:6c:c3:c2:2e:2a:f2:4f:5b:eb:27:d5:df:f7:3d:5d:74:e1:66
SHA1 Fingerprint: cb:02:59:71:48:26:c8:67:d1:42:2c:31:0b:88:15:01:60:39:8f:0b
SHA1 Fingerprint: 46:de:f6:3b:5c:e6:1c:f8:ba:0d:e2:e6:63:9c:10:19:d0:ed:14:f3
SHA1 Fingerprint: 58:0a:6f:4c:c4:e4:b6:69:b9:eb:dc:1b:2b:3e:08:7b:80:d0:67:8d
```

After the mentioned commit:

```
./src/mokutil --db | grep -i fingerprint
SHA1 Fingerprint: 2d:78:46:3f:12:ae:67:aa:7a:38:5e:3e:10:1b:19:1f:54:53:ed:53
SHA1 Fingerprint: b6:a8:c6:49:ab:aa:7e:73:eb:0e:56:b8:f1:60:be:bb:88:12:63:00
SHA1 Fingerprint: 41:89:4b:1c:12:20:e5:43:39:c2:b2:8b:80:10:f6:ea:64:4e:d1:f0
SHA1 Fingerprint: 36:1b:57:ee:87:53:c4:ee:73:56:90:d1:a9:a1:85:1e:82:58:8c:21
```

Fix this by using a different pointer, than the one passed by reference to
the d2i_X509() function, to calculate the certificates' SHA1 fingerprints.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>