### PR TITLE
SBAT revocation update support

### DIFF
--- a/man/mokutil.1
+++ b/man/mokutil.1
@@ -75,7 +75,9 @@ mokutil \- utility to manipulate machine owner keys
 .br
 \fBmokutil\fR [--dbx]
 .br
-\fBmokutil\fR [--sbat]
+\fBmokutil\fR [--list-sbat-revocations]
+.br
+\fBmokutil\fR [--set-sbat-policy (\fIlatest\fR | \fIprevious\fR | \fIdelete\fR)]
 .br
 \fBmokutil\fR [--timeout \fI-1,0..0x7fff\fR]
 .br
@@ -180,8 +182,16 @@ List the keys in the secure boot signature store (db)
 \fB--dbx\fR
 List the keys in the secure boot blacklist signature store (dbx)
 .TP
-\fB--sbat\fR
+\fB--list-sbat-revocations\fR
 List the entries in the Secure Boot Advanced Targeting store (SBAT)
+.TP
+\fB--set-sbat-policy (\fIlatest\fR | \fIprevious\fR | \fIdelete\fR)\fR
+Set the SbatPolicy UEFI Variable to have shim apply either the latest
+or the previous SBAT revocations.  If UEFI Secure Boot is disabled, then
+delete will reset the SBAT revocations to an empty revocation list.
+While latest and previous are persistent configuration, delete will be
+cleared by shim on the next boot whether or not it succeeds. The default
+behavior is for shim to apply the previous revocations.
 .TP
 \fB--timeout\fR
 Set the timeout for MOK prompt

--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -85,6 +85,7 @@
 #define LIST_SBAT          (1 << 24)
 #define FB_VERBOSITY       (1 << 25)
 #define FB_NOREBOOT        (1 << 26)
+#define SET_SBAT           (1 << 27)
 
 #define DEFAULT_CRYPT_METHOD SHA512_BASED
 #define DEFAULT_SALT_SIZE    SHA512_SALT_MAX
@@ -131,12 +132,13 @@ print_help ()
 	printf ("  --set-verbosity <true/false>\t\tSet the verbosity bit for shim\n");
 	printf ("  --set-fallback-verbosity <true/false>\t\tSet the verbosity bit for fallback\n");
 	printf ("  --set-fallback-noreboot <true/false>\t\tPrevent fallback from automatically rebooting\n");
+	printf ("  --set-sbat-policy <latest/previous/delete>\t\tApply Latest, Previous, or Blank SBAT revocations\n");
 	printf ("  --pk\t\t\t\t\tList the keys in PK\n");
 	printf ("  --kek\t\t\t\t\tList the keys in KEK\n");
 	printf ("  --db\t\t\t\t\tList the keys in db\n");
 	printf ("  --dbx\t\t\t\t\tList the keys in dbx\n");
 	printf ("  --timeout <-1,0..0x7fff>\t\tSet the timeout for MOK prompt\n");
-	printf ("  --sbat\t\t\t\tList the entries in SBAT\n");
+	printf ("  --list-sbat-revocations\t\t\t\tList the entries in SBAT\n");
 	printf ("\n");
 	printf ("Supplimentary Options:\n");
 	printf ("  --hash-file <hash file>\t\tUse the specific password hash\n");
@@ -1737,6 +1739,26 @@ list_db (const DBName db_name)
 	return -1;
 }
 
+static int
+manage_sbat (const uint8_t sbat_policy)
+{
+	if (sbat_policy) {
+		uint32_t attributes = EFI_VARIABLE_NON_VOLATILE
+				      | EFI_VARIABLE_BOOTSERVICE_ACCESS
+				      | EFI_VARIABLE_RUNTIME_ACCESS;
+		if (efi_set_variable (efi_guid_shim, "SbatPolicy",
+				      (uint8_t *)&sbat_policy,
+				      sizeof (sbat_policy),
+				      attributes, S_IRUSR | S_IWUSR) < 0) {
+			fprintf (stderr, "Failed to set SbatPolicy\n");
+			return -1;
+		}
+	} else {
+		return test_and_delete_mok_var ("SbatPolicy");
+	}
+	return 0;
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -1753,6 +1775,7 @@ main (int argc, char *argv[])
 	uint8_t verbosity = 0;
 	uint8_t fb_verbosity = 0;
 	uint8_t fb_noreboot = 0;
+	uint8_t sbat_policy = 0;
 	DBName db_name = MOK_LIST_RT;
 	int ret = -1;
 	int sb_check;
@@ -1795,10 +1818,12 @@ main (int argc, char *argv[])
 			{"set-verbosity",      required_argument, 0, 0  },
 			{"set-fallback-verbosity", required_argument, 0, 0  },
 			{"set-fallback-noreboot", required_argument, 0, 0  },
+			{"set-sbat-policy",    required_argument, 0, 0  },
 			{"pk",                 no_argument,       0, 0  },
 			{"kek",                no_argument,       0, 0  },
 			{"db",                 no_argument,       0, 0  },
 			{"dbx",                no_argument,       0, 0  },
+			{"list-sbat-revocations", no_argument,       0, 0  },
 			{"sbat",               no_argument,       0, 0  },
 			{"timeout",            required_argument, 0, 0  },
 			{"ca-check",           no_argument,       0, 0  },
@@ -1879,6 +1904,16 @@ main (int argc, char *argv[])
 					fb_noreboot = 0;
 				else
 					command |= HELP;
+			} else if (strcmp (option, "set-sbat-policy") == 0) {
+				command |= SET_SBAT;
+				if (strcmp (optarg, "latest") == 0)
+					sbat_policy = 1;
+				else if (strcmp (optarg, "previous") == 0)
+					sbat_policy = 2;
+				else if (strcmp (optarg, "delete") == 0)
+					sbat_policy = 3;
+				else
+					command |= HELP;
 			} else if (strcmp (option, "pk") == 0) {
 				if (db_name != MOK_LIST_RT) {
 					command |= HELP;
@@ -1903,6 +1938,8 @@ main (int argc, char *argv[])
 				} else {
 					db_name = DBX;
 				}
+			}  else if (strcmp (option, "list-sbat-revocations") == 0) {
+				command |= LIST_SBAT;
 			}  else if (strcmp (option, "sbat") == 0) {
 				command |= LIST_SBAT;
 			} else if (strcmp (option, "timeout") == 0) {
@@ -2176,6 +2213,9 @@ main (int argc, char *argv[])
 			break;
 		case LIST_SBAT:
 			ret = print_var_content ("SbatLevelRT", efi_guid_shim);
+			break;
+		case SET_SBAT:
+			ret = manage_sbat(sbat_policy);
 			break;
 		default:
 			print_help ();


### PR DESCRIPTION
Control how shim will apply SBAT revocations:

 mokutil --set-sbat-policy latest

	applies the latest SBAT revocations
	(default behavior)

 mokutil --set-sbat-policy previous

	applies previous SBAT revocations to
	allow falling back to an older release

 In both of the above cases shim will only apply SBAT revocations that
are newer than the ones currently installed.

 mokutil --set-sbat-policy delete

	resets SBAT revocations only if Secure
	Boot is disabled. This setting does not
	persist.

Signed-off-by: Jan Setje-Eilers <Jan.SetjeEilers@oracle.com>