### PR TITLE
Show usage instead of aborting on bad flags

### DIFF
--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -2087,10 +2087,9 @@ main (int argc, char *argv[])
 			goto out;
 		case 'h':
 		case '?':
+		default:
 			command |= HELP;
 			break;
-		default:
-			abort ();
 		}
 	}
 


### PR DESCRIPTION
Aborting here just confuses users and is sufficiently unexpected to
cause the filing of bugs.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2087066
Signed-off-by: Robbie Harwood <rharwood@redhat.com>