### PR TITLE
Add support for SSPPolicy, depricate --set-sbat-policy delete

### DIFF
--- a/man/mokutil.1
+++ b/man/mokutil.1
@@ -77,7 +77,7 @@ mokutil \- utility to manipulate machine owner keys
 .br
 \fBmokutil\fR [--list-sbat-revocations]
 .br
-\fBmokutil\fR [--set-sbat-policy (\fIlatest\fR | \fIprevious\fR | \fIdelete\fR)]
+\fBmokutil\fR [--set-sbat-policy (\fIlatest\fR | \fIautomatic\fR | \fIdelete\fR)]
 .br
 \fBmokutil\fR [--timeout \fI-1,0..0x7fff\fR]
 .br
@@ -189,14 +189,14 @@ List the keys in the secure boot blacklist signature store (dbx)
 \fB--list-sbat-revocations\fR
 List the entries in the Secure Boot Advanced Targeting store (SBAT)
 .TP
-\fB--set-sbat-policy (\fIlatest\fR | \fIprevious\fR)\fR
+\fB--set-sbat-policy (\fIlatest\fR | \fIautomatic\fR)\fR
 Set the SbatPolicy UEFI Variable to have shim apply either the latest
-or the previous SBAT revocations.  If UEFI Secure Boot is disabled, then
+or the automatic SBAT revocations.  If UEFI Secure Boot is disabled, then
 shim will automatically delete SBAT revocations
 .TP
-\fB--set-ssp-policy (\fIlatest\fR | \fIprevious\fR | \fIdelete\fR)\fR
+\fB--set-ssp-policy (\fIlatest\fR | \fIautomatic\fR | \fIdelete\fR)\fR
 Set the SspPolicy UEFI Variable to have shim apply either the latest
-or the previous Windows SkuSiPolicy to manage bootmgr revocations. Since
+or the automatic Windows SkuSiPolicy to manage bootmgr revocations. Since
 these are non-native revocations, shim will not automatically delete
 them. If this is needed, spp-policy can be set to delete when Secure
 Boot is disabled. The delete policy is non-persistent.

--- a/man/mokutil.1
+++ b/man/mokutil.1
@@ -189,13 +189,17 @@ List the keys in the secure boot blacklist signature store (dbx)
 \fB--list-sbat-revocations\fR
 List the entries in the Secure Boot Advanced Targeting store (SBAT)
 .TP
-\fB--set-sbat-policy (\fIlatest\fR | \fIprevious\fR | \fIdelete\fR)\fR
+\fB--set-sbat-policy (\fIlatest\fR | \fIprevious\fR)\fR
 Set the SbatPolicy UEFI Variable to have shim apply either the latest
 or the previous SBAT revocations.  If UEFI Secure Boot is disabled, then
-delete will reset the SBAT revocations to an empty revocation list.
-While latest and previous are persistent configuration, delete will be
-cleared by shim on the next boot whether or not it succeeds. The default
-behavior is for shim to apply the previous revocations.
+shim will automatically delete SBAT revocations
+.TP
+\fB--set-ssp-policy (\fIlatest\fR | \fIprevious\fR | \fIdelete\fR)\fR
+Set the SspPolicy UEFI Variable to have shim apply either the latest
+or the previous Windows SkuSiPolicy to manage bootmgr revocations. Since
+these are non-native revocations, shim will not automatically delete
+them. If this is needed, spp-policy can be set to delete when Secure
+Boot is disabled. The delete policy is non-persistent.
 .TP
 \fB--timeout\fR
 Set the timeout for MOK prompt

--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -139,10 +139,10 @@ print_help ()
 			"\tPrevent fallback from automatically rebooting\n");
 	printf ("  --trust-mok\t\t\t\tTrust MOK keys within the kernel keyring\n");
 	printf ("  --untrust-mok\t\t\t\tDo not trust MOK keys\n");
-	printf ("  --set-sbat-policy <latest/previous>"
-			"\tApply Lates or Previous SBAT revocations\n");
-	printf ("  --set-ssp-policy <latest/previous/delete>\n"
-			"\t\t\t\t\tApply Latest, Previous, or delete SkuSiPolicy\n");
+	printf ("  --set-sbat-policy <latest/automatic>"
+			"\tApply Latest or Automatic SBAT revocations\n");
+	printf ("  --set-ssp-policy <latest/automatic/delete>\n"
+			"\t\t\t\t\tApply Latest, Automatic, or delete SkuSiPolicy\n");
 	printf ("  --pk\t\t\t\t\tList the keys in PK\n");
 	printf ("  --kek\t\t\t\t\tList the keys in KEK\n");
 	printf ("  --db\t\t\t\t\tList the keys in db\n");
@@ -1956,7 +1956,8 @@ main (int argc, char *argv[])
 				command |= SET_SBAT;
 				if (strcmp (optarg, "latest") == 0)
 					policy = 1;
-				else if (strcmp (optarg, "previous") == 0)
+				else if ((strcmp (optarg, "previous") == 0) ||
+					 (strcmp (optarg, "automatic") == 0))
 					policy = 2;
 				else if (strcmp (optarg, "delete") == 0)
 					policy = 3;
@@ -1966,7 +1967,8 @@ main (int argc, char *argv[])
 				command |= SET_SSP;
 				if (strcmp (optarg, "latest") == 0)
 					policy = 1;
-				else if (strcmp (optarg, "previous") == 0)
+				else if ((strcmp (optarg, "previous") == 0) ||
+					 (strcmp (optarg, "automatic") == 0))
 					policy = 2;
 				else if (strcmp (optarg, "delete") == 0)
 					policy = 3;

--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -133,8 +133,10 @@ print_help ()
 	printf ("  --import-hash <hash>\t\t\tImport a hash into MOK or MOKX\n");
 	printf ("  --delete-hash <hash>\t\t\tDelete a hash in MOK or MOKX\n");
 	printf ("  --set-verbosity <true/false>\t\tSet the verbosity bit for shim\n");
-	printf ("  --set-fallback-verbosity <true/false>\t\tSet the verbosity bit for fallback\n");
-	printf ("  --set-fallback-noreboot <true/false>\t\tPrevent fallback from automatically rebooting\n");
+	printf ("  --set-fallback-verbosity <true/false>"
+			"\tSet the verbosity bit for fallback\n");
+	printf ("  --set-fallback-noreboot <true/false>"
+			"\tPrevent fallback from automatically rebooting\n");
 	printf ("  --trust-mok\t\t\t\tTrust MOK keys within the kernel keyring\n");
 	printf ("  --untrust-mok\t\t\t\tDo not trust MOK keys\n");
 	printf ("  --set-sbat-policy <latest/previous>"

--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2012-2020 Gary Lin <glin@suse.com>
  * Copyright (C) 2012 Matthew Garrett <mjg@redhat.com>
  *
@@ -88,6 +88,7 @@
 #define TRUST_MOK          (1 << 27)
 #define UNTRUST_MOK        (1 << 28)
 #define SET_SBAT           (1 << 29)
+#define SET_SSP            (1 << 30)
 
 #define DEFAULT_CRYPT_METHOD SHA512_BASED
 #define DEFAULT_SALT_SIZE    SHA512_SALT_MAX
@@ -136,13 +137,16 @@ print_help ()
 	printf ("  --set-fallback-noreboot <true/false>\t\tPrevent fallback from automatically rebooting\n");
 	printf ("  --trust-mok\t\t\t\tTrust MOK keys within the kernel keyring\n");
 	printf ("  --untrust-mok\t\t\t\tDo not trust MOK keys\n");
-	printf ("  --set-sbat-policy <latest/previous/delete>\t\tApply Latest, Previous, or Blank SBAT revocations\n");
+	printf ("  --set-sbat-policy <latest/previous>"
+			"\tApply Lates or Previous SBAT revocations\n");
+	printf ("  --set-ssp-policy <latest/previous/delete>\n"
+			"\t\t\t\t\tApply Latest, Previous, or delete SkuSiPolicy\n");
 	printf ("  --pk\t\t\t\t\tList the keys in PK\n");
 	printf ("  --kek\t\t\t\t\tList the keys in KEK\n");
 	printf ("  --db\t\t\t\t\tList the keys in db\n");
 	printf ("  --dbx\t\t\t\t\tList the keys in dbx\n");
 	printf ("  --timeout <-1,0..0x7fff>\t\tSet the timeout for MOK prompt\n");
-	printf ("  --list-sbat-revocations\t\t\t\tList the entries in SBAT\n");
+	printf ("  --list-sbat-revocations\t\tList the entries in SBAT\n");
 	printf ("\n");
 	printf ("Supplimentary Options:\n");
 	printf ("  --hash-file <hash file>\t\tUse the specific password hash\n");
@@ -1774,21 +1778,27 @@ list_db (const DBName db_name)
 }
 
 static int
-manage_sbat (const uint8_t sbat_policy)
+manage_policy (unsigned int command, const uint8_t policy)
 {
-	if (sbat_policy) {
+	const char *varname;
+	if (command == SET_SBAT)
+		varname = "SbatPolicy";
+	if (command == SET_SSP)
+		varname = "SSPPolicy";
+
+	if (policy) {
 		uint32_t attributes = EFI_VARIABLE_NON_VOLATILE
 				      | EFI_VARIABLE_BOOTSERVICE_ACCESS
 				      | EFI_VARIABLE_RUNTIME_ACCESS;
-		if (efi_set_variable (efi_guid_shim, "SbatPolicy",
-				      (uint8_t *)&sbat_policy,
-				      sizeof (sbat_policy),
+		if (efi_set_variable (efi_guid_shim, varname,
+				      (uint8_t *)&policy,
+				      sizeof (policy),
 				      attributes, S_IRUSR | S_IWUSR) < 0) {
 			fprintf (stderr, "Failed to set SbatPolicy\n");
 			return -1;
 		}
 	} else {
-		return test_and_delete_mok_var ("SbatPolicy");
+		return test_and_delete_mok_var (varname);
 	}
 	return 0;
 }
@@ -1809,7 +1819,7 @@ main (int argc, char *argv[])
 	uint8_t verbosity = 0;
 	uint8_t fb_verbosity = 0;
 	uint8_t fb_noreboot = 0;
-	uint8_t sbat_policy = 0;
+	uint8_t policy = 0;
 	DBName db_name = MOK_LIST_RT;
 	int ret = -1;
 	int sb_check;
@@ -1850,6 +1860,7 @@ main (int argc, char *argv[])
 			{"trust-mok",          no_argument,       0, 0  },
 			{"untrust-mok",        no_argument,       0, 0  },
 			{"set-sbat-policy",    required_argument, 0, 0  },
+			{"set-ssp-policy",     required_argument, 0, 0  },
 			{"pk",                 no_argument,       0, 0  },
 			{"kek",                no_argument,       0, 0  },
 			{"db",                 no_argument,       0, 0  },
@@ -1942,11 +1953,21 @@ main (int argc, char *argv[])
 			} else if (strcmp (option, "set-sbat-policy") == 0) {
 				command |= SET_SBAT;
 				if (strcmp (optarg, "latest") == 0)
-					sbat_policy = 1;
+					policy = 1;
 				else if (strcmp (optarg, "previous") == 0)
-					sbat_policy = 2;
+					policy = 2;
 				else if (strcmp (optarg, "delete") == 0)
-					sbat_policy = 3;
+					policy = 3;
+				else
+					command |= HELP;
+			} else if (strcmp (option, "set-ssp-policy") == 0) {
+				command |= SET_SSP;
+				if (strcmp (optarg, "latest") == 0)
+					policy = 1;
+				else if (strcmp (optarg, "previous") == 0)
+					policy = 2;
+				else if (strcmp (optarg, "delete") == 0)
+					policy = 3;
 				else
 					command |= HELP;
 			} else if (strcmp (option, "pk") == 0) {
@@ -2265,7 +2286,8 @@ main (int argc, char *argv[])
 			ret = print_var_content ("SbatLevelRT", efi_guid_shim);
 			break;
 		case SET_SBAT:
-			ret = manage_sbat(sbat_policy);
+		case SET_SSP:
+			ret = manage_policy(command, policy);
 			break;
 		default:
 			print_help ();


### PR DESCRIPTION
This unlocks the ability to control bootmgr revocation polity in a similar manner to what we did with sbat levels. There are some subtle differences since we want to be more aggressive with our own policy than with one that could be managed by an external OS. That choice may evolve over time.

Thank you for any and all comments, including any naming discussion.