### PR TITLE
Avoid conflicting efi_char16_t type definitions

### DIFF
--- a/src/mokutil.h
+++ b/src/mokutil.h
@@ -33,13 +33,14 @@
 #define __MOKUTIL_H__
 
 #include <ctype.h>
-#include <wchar.h>
 
 #include "signature.h"
 
 typedef unsigned long efi_status_t;
 typedef uint8_t efi_bool_t;
-typedef wchar_t efi_char16_t;		/* UNICODE character */
+#ifndef efi_char16_t
+typedef uint16_t efi_char16_t;		/* UNICODE character */
+#endif
 
 typedef enum {
 	DELETE_MOK = 0,


### PR DESCRIPTION
It's not necessary to define 'efi_char16_t' as 'wchar_t' since we don't need any wchar functions. Besides, it may conflict with efivar-38. This commit defines 'efi_char16_t' as 'uint16_t' and adds the conditional check to avoid the potential conflict.

Fixes: https://github.com/lcp/mokutil/issues/66