### PR TITLE
return zero in case --test-key is enrolled

### DIFF
--- a/src/mokutil.c
+++ b/src/mokutil.c
@@ -1590,7 +1590,7 @@ test_key (const MokRequest req, const char *key_file)
 		ret = 1;
 	} else {
 		print_skip_message (key_file, key, read_size, req);
-		ret = 1;
+		ret = 0;
 	}
 
 error:


### PR DESCRIPTION
Otherwise it returns non-zero even if key is enrolled, indicating a negative result.

With this change, the --test-key return code would be following

    [root@localhost ~]# mokutil --test-key sb_cert.cer
    sb_cert.cer is already enrolled
    [root@localhost ~]# echo $?
    0

instead of

    [root@localhost ~]# mokutil --test-key sb_cert.cer
    sb_cert.cer is already enrolled
    [root@localhost ~]# echo $?
    1