### PR TITLE
Removed duplicate -Wcast-align

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,11 +50,11 @@ fi
 
 if test "$GCC" = "yes"; then
 	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wall -Wextra"
-	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wcast-align -Wno-uninitialized"
+	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wcast-align"
+	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wno-uninitialized"
 	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wmissing-declarations"
 #	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wredundant-decls"
 #	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wpointer-arith"
-	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wcast-align"
 	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wwrite-strings"
 	WARNINGFLAGS_C="$WARNINGFLAGS_C -Winit-self"
 	WARNINGFLAGS_C="$WARNINGFLAGS_C -Wreturn-type"


### PR DESCRIPTION
This duplicates https://github.com/lcp/mokutil/pull/48. However, https://github.com/lcp/mokutil/pull/48 specifically removed the duplication only for loongarch64. This pull request removes it for all platforms.